### PR TITLE
Fix for multiclicking to reveal thumbnails

### DIFF
--- a/client/imager.js
+++ b/client/imager.js
@@ -77,6 +77,8 @@ var Hidamari = {
 			return;
 		e.preventDefault();
 		var revealed = this.model.get('thumbnailRevealed');
+		if (revealed === undefined)
+			revealed = false;
 		this.renderThumbnail(revealed);
 		this.$el.children('figure').find('.imageSrc').text(revealed ? '[Show]' : '[Hide]');
 	},


### PR DESCRIPTION
When changing the thumbnail mode, existing models get their "thumbnailRevealed" attribute set to false on the re-render by the function changeThumbnailStyle.
This does not happen for Posts that get added afterwards or on a page reload with thumbnails already set to hidden.
Which is why renderThumbnail got called with an undefined and would overwrite its hide argument to true on line 34, which would properly initialize the thumbnailRevealed attribute to false and then afterwards the Show button would be falsely set to [Hide] by the revealThumbnail function.

With this change new posts with an undefined thumbnailRevealed attribute call the renderThumbnail function directly with an argument of false, skipping the extra click while working as usual for already initialized values.