### PR TITLE
Fixing the postalert sync

### DIFF
--- a/client/postalert.js
+++ b/client/postalert.js
@@ -73,7 +73,7 @@
             } else {
               updateInfo(cumSum, 0, board);
             }
-            if (cumSum != cachedCumSum) setItem(board + "threads", threads);
+            setItem(board + "threads", threads);
           }
         });
       }


### PR DESCRIPTION
The sync ignored the current thread so after being offline for a couple of hours it only updated the threads for other boards but not the one I was on and switching to another board would then display 120 posts on /radio/.
Always updating the cache is better in this case.