### PR TITLE
Fixed behavior with new threads and caching.

### DIFF
--- a/client/postalert.js
+++ b/client/postalert.js
@@ -85,6 +85,7 @@
     var board = msg[0];
     var cached = getItem(board + "threads");
     var newValues = $.extend(true, {}, cached);
+    if (!newValues[op]) newValues[op] = 0;
     newValues[op] += 1;
     setItem(board + "threads", newValues);
     if (op !== THREAD) updateInfo(2, 1, board);


### PR DESCRIPTION
When receiving the alert for a new thread, the value of newValues[op] is undefined, which resulted in the tabCache to receive a NaN item for the thread. 
The localstorage would receive a null value and a reload would just fix everything, but if a connection loss occured the alert sync would push all the updates for that thread into the display, doubling the already displayed amount, since it had no posts it could sum up for that thread.