### PR TITLE
rotate thumbnails

### DIFF
--- a/less/base.less
+++ b/less/base.less
@@ -138,6 +138,7 @@ h3 {
  position: fixed;
  pointer-events: none;
  display: flex;
+ image-orientation: from-image;
  z-index: 300;
  img,
  video {


### PR DESCRIPTION
Preview image is on the board, post 768090

The position of the -auto-orient argument is important, otherwise it rotates and then might apply a background with the original bounds, happened a few times during testing with Carlito's rotated image, it had a small strip on the bottom or the right with the background color and was kinda squished.

I run the exiftool a second time, just to read the orientation, if it's either 90 or 270 and then swap the dimensions around. I had to set a flag on the image object itself because the converter needs the original size to start with before rotating in the end.
The swapping of dimensions is not only for the calculations but also displays the image with the rotated size in the post.
