### PR TITLE
Making the actual function behave like the fallback.

### DIFF
--- a/client/scroll.js
+++ b/client/scroll.js
@@ -122,7 +122,7 @@ var at_bottom = function() {
 };
 if (window.scrollMaxY !== undefined)
 	at_bottom = function () {
-		return window.scrollMaxY <= window.scrollY;
+		return window.scrollMaxY -5 <= window.scrollY;
 	};
 
 (function () {


### PR DESCRIPTION
On zoomed in browsers the scrollY can end up with a smaller value than scrollMaxY even if you're at the very bottom.
Hopefully closes #126 